### PR TITLE
Render search form

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -40,7 +40,9 @@ export function searchArtworks(query) {
 	 * TODO: replace with path to `/artworks/search/` endpoint,
 	 * as described in README.md.
 	 */
-	const requestUrl = `./ARTWORKS_SEARCH_RESULT.json`;
+	const requestUrl = `https://api.artic.edu/api/v1/artworks/search?q=${query}&query[term][is_public_domain]=true&fields=artist_title,date_display,image_id,thumbnail.alt_text,thumbnail.width,thumbnail.height,title
+
+`;
 
 	/**
 	 * We know the API serves JSON data, but

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -3,10 +3,14 @@ import { useState } from 'react';
 import { searchArtworks } from '../api';
 import { SearchForm } from './SearchForm';
 import { Footer } from './Footer';
-
+import ImageDetailsPage from './ImageDetailsPage.jsx';
 import './App.css';
 
 export function App() {
+	const [query, setQuery] = useState('');
+	const [artSelection, setArtSelection] = useState('');
+	const [showArtDetails, setShowArtDetails] = useState(false);
+
 	function onSearchSubmit(query) {
 		// Search for the users's query.
 		// TODO: render the results, instead of logging them to the console.
@@ -15,14 +19,43 @@ export function App() {
 		// our UI, we need to make real requests!
 		// @see: ./src/api.js
 		searchArtworks(query).then((json) => {
-			console.log(json);
+			setQuery(json.data);
+			return json.data;
 		});
 	}
 
+	function onArtSelection(artSelection) {
+		setArtSelection(artSelection);
+		setShowArtDetails(true);
+	}
+
+	const toggleDetails = () => {
+		setShowArtDetails(false);
+	};
+
 	return (
 		<div className="App">
-			<h1>TCL Career Lab Art Finder</h1>
-			<SearchForm onSearchSubmit={onSearchSubmit} />
+			{showArtDetails ? (
+				<ImageDetailsPage data={artSelection} showDetails={toggleDetails} />
+			) : (
+				<div>
+					<h1>TCL Career Lab Art Finder</h1>
+					<SearchForm onSearchSubmit={onSearchSubmit} />
+					<ul>
+						{query ? (
+							query.map((query) => (
+								<li key={query.image_id}>
+									<button onClick={() => onArtSelection(query)}>
+										{query.title} by {query.artist_title ?? 'Unknown Artist'}
+									</button>
+								</li>
+							))
+						) : (
+							<span></span>
+						)}
+					</ul>
+				</div>
+			)}
 			<Footer />
 		</div>
 	);

--- a/src/components/ImageDetailsPage.css
+++ b/src/components/ImageDetailsPage.css
@@ -1,0 +1,15 @@
+.image-details {
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	align-items: center;
+}
+
+button {
+	width: fit-content;
+	height: fit-content;
+}
+
+img {
+	margin: auto;
+}

--- a/src/components/ImageDetailsPage.jsx
+++ b/src/components/ImageDetailsPage.jsx
@@ -1,0 +1,28 @@
+import './ImageDetailsPage.css';
+function ImageDetailsPage({ data, showDetails }) {
+	const { image_id, title, artist_title, thumbnail } = data;
+
+	return (
+		<section>
+			<div className="image-details">
+				<h2>
+					{title} by {artist_title ?? 'Unknown Artist'}
+				</h2>
+				<button
+					onClick={() => {
+						console.log(showDetails);
+						showDetails(false);
+					}}
+				>
+					Back
+				</button>
+			</div>
+			<img
+				alt={thumbnail.alt_text}
+				src={`https://www.artic.edu/iiif/2/${image_id}/full/843,/0/default.jpg`}
+			/>
+		</section>
+	);
+}
+
+export default ImageDetailsPage;

--- a/src/components/SearchForm.jsx
+++ b/src/components/SearchForm.jsx
@@ -9,7 +9,8 @@ export function SearchForm({ onSearchSubmit }) {
 		setQuery(evt.target.value);
 	}
 
-	function handleFormSubmit() {
+	function handleFormSubmit(e) {
+		e.preventDefault();
 		onSearchSubmit(query);
 	}
 

--- a/src/index.css
+++ b/src/index.css
@@ -16,8 +16,25 @@ body {
 	-moz-osx-font-smoothing: grayscale;
 }
 
+h1 {
+	text-align: center;
+}
+ul {
+	margin: auto;
+}
+li > button {
+	font-size: 2.4rem;
+	text-align: left;
+	text-decoration: underline;
+	border: none;
+	background-color: transparent;
+	cursor: pointer;
+}
+
 button,
 input {
+	width: 80%;
+	margin: auto;
 	font-family: inherit;
 	font-size: 100%;
 	line-height: inherit;


### PR DESCRIPTION
## Description

The changes complete the AIC Art Finder UI that allows the user to search for artworks within the AIC API and render a list of matching results from the search query. The searchArtworks function was refactored to make the fetch requests to the AIC API instead of the local cache. This code also adds a preventDefault event in the searchForm to prevent the page from refreshing on form submission. 

Users can see more information from each search result, such as title, artist name, and picture of the artwork, by clicking on the list item. There is also a back button on the image details page that allows the user to return back to their list of search results.

The app allows users who rely on assisted technology such as screen readers to tab through the app.

## Related Issue

n/a

## Acceptance Criteria

- [x] Create a `searchArtworks` function for making GET requests to `/search/artworks/`. See `src/api.js`
  - [x] Request a local copy of data in `searchArtworks` to avoid making too many requests to the AIC's search endpoint while the app is in development
  - [x] **When the UI is complete**, ensure that `searchArtworks` makes requests to the AIC's `/artworks/search/` endpoint, as described in "Using the `/artworks/search/` endpoint"
- [x] Create a `SearchForm` component that will allow the user to perform a search. See `src/components/SearchForm.jsx`
  - [x] Fix a known bug: the whole app refreshes when `SearchForm` is submitted
- [x] In the `App` component, render
  - [x] the `SearchForm` component and
  - [x] a list of results including _the name of the piece_ and _the artist who created the piece_.
- [x] Create an `ImageDetailsPage` component.
- [x] Render `ImageDetailsPage` when the user clicks the title of a piece in the list of results. 💡
- [x] In the `ImageDetailsPage` component, render
  - [x] the name of the piece
  - [x] the artist who created the piece
  - [x] the image associated with the piece (don't forget its alt text!)
  - [x] a back button that returns the user to the list of results


## Type of Changes

<!-- Put an `✓` for the applicable box: -->

|     | Type                       |
| --- | -------------------------- |
| ✓      | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|     | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |

## Updates

### Before

<img width="1120" alt="Screenshot 2023-06-13 at 12 46 29 PM" src="https://github.com/yiremorlans/take-home-assignment/assets/93563580/34f879cc-3670-46eb-9a63-f7a01711fdc5">

### After

<img width="1120" alt="Screenshot 2023-06-13 at 12 48 23 PM" src="https://github.com/yiremorlans/take-home-assignment/assets/93563580/7383412c-eb6c-4076-8872-a4e0d3ae4e55">

<img width="1120" alt="Screenshot 2023-06-13 at 12 48 56 PM" src="https://github.com/yiremorlans/take-home-assignment/assets/93563580/e62fc09c-429f-4814-9bbf-7b3b828b1f09">


## Testing Steps / QA Criteria

Performed accessibility audit to ensure the app can be navigated through tabs.